### PR TITLE
Fix: update repository clone URL in README

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -62,7 +62,7 @@ Dado que este es un proyecto estático, no se requiere configuración de build o
 
 1. Clona el repositorio:
    ```bash
-   git clone <repository-link>
+   git clone https://github.com/Alyona-K/pawtastic
    ```
 
 2. Abre la carpeta del proyecto en VS Code.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Since this is a static project, no build or JavaScript setup is required. **Sass
 
 1. Clone the repository:
    ```bash
-   git clone <repository-link>
+   git clone https://github.com/Alyona-K/pawtastic
    ```
 
 2. Open the project folder in VS Code.


### PR DESCRIPTION
Replaced placeholder <repository-link> with the actual GitHub repository URL for easier cloning: https://github.com/Alyona-K/pawtastic